### PR TITLE
Fixing prompt relation extraction component test that failed silently

### DIFF
--- a/tests/test_prompt_relationextraction_component.py
+++ b/tests/test_prompt_relationextraction_component.py
@@ -49,7 +49,7 @@ def test_prompt_relation_extraction(
         """
 
         def test_api(target):
-            return api_response
+            return [api_response]
 
         return test_api
 
@@ -74,8 +74,9 @@ def test_prompt_relation_extraction(
 
     doc = nlp(sample_thread)
 
-    assert doc._.relation_triplets is not None
-    for triplet in doc._.relation_triplets:
+    doc_relation_triplets = doc._.relation_triplets
+    assert doc_relation_triplets is not None and len(doc_relation_triplets) > 0
+    for triplet in doc_relation_triplets:
         assert isinstance(triplet, SpanTriplet)
         triplet in expected_span_triplets
 


### PR DESCRIPTION
I noticed by chance that this test was not failing, even though the output was empty. Not sure if this was always the case or if it is caused by some of my recent changes.

Regardless, no triplet annotations were actually put on the document because `prompt_relation_component.set_annotations()` would would get a string instead of a list as the `prompt_outputs` argument and thus loop over the string instead.

The annotations are now added, and the assertion is a bit more strict.