### PR TITLE
Kf/generic pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,4 @@ data/
 *extracted_triplets*
 paper/*ndjson
 paper/fig/*
+output/

--- a/config/default.toml
+++ b/config/default.toml
@@ -1,0 +1,19 @@
+[base]
+output_root = "output"
+language = "da"
+
+[preprocessing]
+enabled = true
+doc_type = "text"
+metadata_fields = ["*"]
+
+[preprocessing.extra]
+basename_as_id = true
+
+[docprocessing]
+enabled = true
+continue_from_last = true
+triplet_extraction_method = "multi2oie"
+
+[corpusprocessing]
+enabled = true

--- a/config/template.toml
+++ b/config/template.toml
@@ -1,0 +1,13 @@
+[project]
+project_name = "PROJECT_NAME"
+output_root = "output"
+language = "da/en"
+
+[preprocessing]
+enabled = true
+input_path = "SOME/INPUT/PATH"
+doc_type = "text/tweets/infomedia"
+
+[docprocessing]
+enabled = true
+triplet_extraction_method = "multi2oie"

--- a/config/template.toml
+++ b/config/template.toml
@@ -1,13 +1,20 @@
-[project]
-project_name = "PROJECT_NAME"
+[base]
 output_root = "output"
 language = "da/en"
 
 [preprocessing]
 enabled = true
-input_path = "SOME/INPUT/PATH"
 doc_type = "text/tweets/infomedia"
+metadata_fields = ["*"]
+
+[preprocessing.extra]
+# specific extra arguments for your preprocessor, e.g. context length for tweets.
+# leave empty unless you have very specific needs
 
 [docprocessing]
 enabled = true
-triplet_extraction_method = "multi2oie"
+continue_from_last = true
+triplet_extraction_method = "multi2oie/prompting"
+
+[corpusprocessing]
+enabled = true

--- a/config/template.toml
+++ b/config/template.toml
@@ -4,7 +4,7 @@ language = "da/en"
 
 [preprocessing]
 enabled = true
-doc_type = "text/tweets/infomedia"
+doc_type = "text/csv/tweets/infomedia"
 metadata_fields = ["*"]
 
 [preprocessing.extra]

--- a/config/template_csv.toml
+++ b/config/template_csv.toml
@@ -1,0 +1,21 @@
+[base]
+output_root = "output"
+language = "en"
+
+[preprocessing]
+enabled = true
+doc_type = "csv"
+metadata_fields = ["*"]
+
+[preprocessing.extra]
+id_column = "id"
+text_column = "body"
+
+[docprocessing]
+enabled = true
+batch_size = 5
+continue_from_last = true
+triplet_extraction_method = "multi2oie"
+
+[corpusprocessing]
+enabled = true

--- a/config/tweets.toml
+++ b/config/tweets.toml
@@ -1,0 +1,11 @@
+[project]
+project_name = "twitter-test-mini"
+output_root = "output"
+language = "da"
+
+[preprocessing]
+input_path = "data/twitter-test-mini.ndjson"
+doc_type = "tweets"
+
+[docprocessing]
+triplet_extraction_method = "multi2oie"

--- a/config/tweets.toml
+++ b/config/tweets.toml
@@ -1,11 +1,11 @@
-[project]
-project_name = "twitter-test-mini"
+[base]
 output_root = "output"
 language = "da"
 
 [preprocessing]
-input_path = "data/twitter-test-mini.ndjson"
 doc_type = "tweets"
 
 [docprocessing]
 triplet_extraction_method = "multi2oie"
+
+[corpusprocessing]

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -2,6 +2,37 @@ Frequently asked questions
 ================================
 
 
+How do I run the pipeline?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you have cloned this project from git, you can run the pipeline via :code:`run.py`
+and, optionally, configurations from :code:`config`.
+
+.. code-block:: bash
+
+   python3 run.py my_project_name my_input_path
+
+
+For a specific pipeline configuration, create one using :code:`config/template.toml` and
+pass it with the :code:`-c` flag.
+
+
+.. code-block:: bash
+
+   python3 run.py my_project_name my_input_path -c config/my-config.toml
+
+
+Project name and input path can also be specified in the configuration instead in which
+case you can do
+
+.. code-block:: bash
+
+   python3 run.py -c config/my-config.toml
+
+If you have installed the package via :code:`pip` and want to integrate (parts of) the
+pipeline into your own workflow, you can use individual components or integrate a
+:code:`Pipeline` object in your script.
+
 
 How do I test the code and run the test suite?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/paper/src/ents_heads_extraction.py
+++ b/paper/src/ents_heads_extraction.py
@@ -1,9 +1,6 @@
 """Pipeline for headwords/entities extractions and frequency count."""
-import multiprocessing
-import os
 
 import spacy
-import torch
 from tqdm import tqdm
 
 from conspiracies.docprocessing.headwordextraction import contains_ents
@@ -12,16 +9,13 @@ from conspiracies.docprocessing.headwordextraction import contains_ents
 def main():
     nlp = spacy.load("en_core_web_lg")
 
-    test_sents = ["Mette Frederiksen is the Danish politician."] * 1000
+    test_sents = ["Mette Frederiksen is the Danish politician."]
 
     config = {"confidence_threshold": 2.7, "model_args": {"batch_size": 10}}
     nlp.add_pipe("relation_extractor", config=config)
     nlp.add_pipe("heads_extraction")
 
-    # multiprocessing and torch with multiple threads result in a deadlock
-    torch.set_num_threads(1)
-
-    pipe = nlp.pipe(test_sents, n_process=os.cpu_count(), batch_size=25)
+    pipe = nlp.pipe(test_sents)
 
     heads_spans = []
     ents_spans = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,10 @@ content-type = "text/markdown"
 
 
 [project.entry-points.spacy_factories]
-"conspiracies/docprocessing/relationextraction/gptprompting" = "conspiracies.docprocessing.relationextraction.gptprompting:create_prompt_relation_extraction_component"
+"prompt_relation_extraction" = "conspiracies.docprocessing.relationextraction.gptprompting:create_prompt_relation_extraction_component"
+"relation_extractor" = "conspiracies.docprocessing.relationextraction.multi2oie:make_relation_extractor"
+"allennlp_coref" = "conspiracies.docprocessing.coref:create_coref_component"
+"heads_extraction" = "conspiracies.docprocessing.headwordextraction:create_headwords_component"
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ dependencies = [
     "umap-learn",
     "hdbscan",
     "sentence-transformers",
-    "stop-words"
+    "stop-words",
+    "bs4",
 ]
 
 [project.license]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "sentence-transformers",
     "stop-words",
     "bs4",
+    "toml"
 ]
 
 [project.license]

--- a/run.py
+++ b/run.py
@@ -6,34 +6,50 @@ from conspiracies.pipeline.config import (
     ProjectConfig,
     PreprocessingConfig,
     DocprocessingConfig,
+    PipelineConfig,
 )
 from conspiracies.pipeline.pipeline import Pipeline
 
 
 if __name__ == "__main__":
     arg_parser = argparse.ArgumentParser()
-    arg_parser.add_argument("project_name")
-    arg_parser.add_argument("input_path")
+    arg_parser.add_argument(
+        "--project_name",
+        required=False,
+    )
+    arg_parser.add_argument(
+        "--input_path",
+        required=False,
+    )
     arg_parser.add_argument(
         "--n_cores",
         default=os.cpu_count(),
     )
+    arg_parser.add_argument(
+        "-c",
+        "--config",
+        required=False,
+    )
     args = arg_parser.parse_args()
 
-    runner = Pipeline()
-    runner.project_config = ProjectConfig(
-        project_name=args.project_name,
-        output_root="output",
-        language="da",
-    )
-    runner.preprocessing_config = PreprocessingConfig(
-        input_path=args.input_path,
-        doc_type="tweets",
-    )
-    runner.docprocessing_config = DocprocessingConfig(
-        triplet_extraction_method="multi2oie",
-    )
+    if args.config:
+        pipeline = Pipeline(config=PipelineConfig.from_toml_file(args.config))
+    else:
+        raise NotImplementedError("Construction site. Sorry!")
+        pipeline = Pipeline(config=PipelineConfig())
+        pipeline.project_config = ProjectConfig(
+            project_name=args.project_name,
+            output_root="output",
+            language="da",
+        )
+        pipeline.preprocessing_config = PreprocessingConfig(
+            input_path=args.input_path,
+            doc_type="tweets",
+        )
+        pipeline.docprocessing_config = DocprocessingConfig(
+            triplet_extraction_method="multi2oie",
+        )
 
-    runner.preprocessing()
-    runner.docprocessing(continue_from_last=True)
-    runner.corpusprocessing()
+    pipeline.preprocessing()
+    pipeline.docprocessing(continue_from_last=True)
+    pipeline.corpusprocessing()

--- a/run.py
+++ b/run.py
@@ -11,16 +11,21 @@ if __name__ == "__main__":
         "project_name",
         nargs="?",
         default=None,
+        help="Name of your project under which various output files will be output"
+        "under output root set in config (the default for which is output/).",
     )
     arg_parser.add_argument(
         "input_path",
         nargs="?",
         default=None,
+        help="Input path for preprocessing of documents. Can be a glob path, e.g."
+        "path/to/files/*.txt. Be mindful of quotes for glob paths.",
     )
     arg_parser.add_argument(
         "-c",
         "--config",
         default="config/default.toml",
+        help="Path to configuration file. Refer to config/template.toml for contents.",
     )
     args = arg_parser.parse_args()
 

--- a/run.py
+++ b/run.py
@@ -1,55 +1,34 @@
 import argparse
-import os
 
 
-from conspiracies.pipeline.config import (
-    ProjectConfig,
-    PreprocessingConfig,
-    DocprocessingConfig,
-    PipelineConfig,
-)
+from conspiracies.pipeline.config import PipelineConfig
 from conspiracies.pipeline.pipeline import Pipeline
 
 
 if __name__ == "__main__":
     arg_parser = argparse.ArgumentParser()
     arg_parser.add_argument(
-        "--project_name",
-        required=False,
+        "project_name",
+        nargs="?",
+        default=None,
     )
     arg_parser.add_argument(
-        "--input_path",
-        required=False,
-    )
-    arg_parser.add_argument(
-        "--n_cores",
-        default=os.cpu_count(),
+        "input_path",
+        nargs="?",
+        default=None,
     )
     arg_parser.add_argument(
         "-c",
         "--config",
-        required=False,
+        default="config/default.toml",
     )
     args = arg_parser.parse_args()
 
-    if args.config:
-        pipeline = Pipeline(config=PipelineConfig.from_toml_file(args.config))
-    else:
-        raise NotImplementedError("Construction site. Sorry!")
-        pipeline = Pipeline(config=PipelineConfig())
-        pipeline.project_config = ProjectConfig(
-            project_name=args.project_name,
-            output_root="output",
-            language="da",
-        )
-        pipeline.preprocessing_config = PreprocessingConfig(
-            input_path=args.input_path,
-            doc_type="tweets",
-        )
-        pipeline.docprocessing_config = DocprocessingConfig(
-            triplet_extraction_method="multi2oie",
-        )
+    cli_args = {
+        "base.project_name": args.project_name,
+        "preprocessing.input_path": args.input_path,
+    }
+    config = PipelineConfig.from_toml_file(args.config, cli_args)
 
-    pipeline.preprocessing()
-    pipeline.docprocessing(continue_from_last=True)
-    pipeline.corpusprocessing()
+    pipeline = Pipeline(config)
+    pipeline.run()

--- a/run.py
+++ b/run.py
@@ -7,7 +7,7 @@ from conspiracies.pipeline.config import (
     PreprocessingConfig,
     DocprocessingConfig,
 )
-from conspiracies.pipeline.runner import Runner
+from conspiracies.pipeline.pipeline import Pipeline
 
 
 if __name__ == "__main__":
@@ -20,7 +20,7 @@ if __name__ == "__main__":
     )
     args = arg_parser.parse_args()
 
-    runner = Runner()
+    runner = Pipeline()
     runner.project_config = ProjectConfig(
         project_name=args.project_name,
         output_root="output",
@@ -35,5 +35,5 @@ if __name__ == "__main__":
     )
 
     runner.preprocessing()
-    runner.docprocessing()
+    runner.docprocessing(continue_from_last=True)
     runner.corpusprocessing()

--- a/run.py
+++ b/run.py
@@ -1,0 +1,42 @@
+import argparse
+import glob
+import json
+import os
+
+
+from conspiracies.docprocessing.docprocessor import DocProcessor
+from conspiracies.document import Document
+from conspiracies.preprocessing.tweets import TweetsPreprocessor
+
+
+def iter_lines_of_files(glob_pattern: str):
+    files = glob.glob(glob_pattern, recursive=True)
+    for file in files:
+        with open(file) as f:
+            for line in f:
+                yield line
+
+
+if __name__ == "__main__":
+    arg_parser = argparse.ArgumentParser()
+    arg_parser.add_argument("project_name")
+    arg_parser.add_argument("input_path")
+    arg_parser.add_argument(
+        "--n_cores",
+        default=os.cpu_count(),
+    )
+    args = arg_parser.parse_args()
+
+    preprocessor = TweetsPreprocessor(args.project_name, n_cores=args.n_cores)
+
+    preprocessor.preprocess_docs(args.input_path)
+
+    doc_processor = DocProcessor()
+
+    doc_processor.process_docs(
+        (
+            json.loads(line, object_hook=Document)
+            for line in iter_lines_of_files(f"output/{args.project_name}/part*.ndjson")
+        ),
+        f"output/{args.project_name}/annotations.ndjson",
+    )

--- a/src/conspiracies/common/fileutils.py
+++ b/src/conspiracies/common/fileutils.py
@@ -1,0 +1,15 @@
+import glob
+import logging
+
+
+def iter_lines_of_files(glob_pattern: str):
+    files = glob.glob(glob_pattern, recursive=True)
+    logging.debug(
+        "The glob pattern '%s' resulted in the following files: %s",
+        glob_pattern,
+        files,
+    )
+    for file in files:
+        with open(file) as f:
+            for line in f:
+                yield line

--- a/src/conspiracies/corpusprocessing/umap_hdb.py
+++ b/src/conspiracies/corpusprocessing/umap_hdb.py
@@ -436,7 +436,7 @@ def main(
         shuffle=True,
     )
 
-    if save:
+    if save and not isinstance(save, str):
         save = path.replace(
             "triplets.txt",
             f"{embedding_model}_dim={dim}_neigh={n_neighbors}"

--- a/src/conspiracies/docprocessing/doc_utils.py
+++ b/src/conspiracies/docprocessing/doc_utils.py
@@ -27,7 +27,8 @@ def _doc_to_json(doc: Doc | Tuple[Doc, str]):
     if id_ is not None:
         json["id"] = id_
     json["semantic_triplets"] = [
-        triplet.to_dict(include_doc=False) for triplet in triplets
+        triplet.to_dict(include_doc=False, include_span_heads=True)
+        for triplet in triplets
     ]
     return json
 

--- a/src/conspiracies/docprocessing/doc_utils.py
+++ b/src/conspiracies/docprocessing/doc_utils.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Union, Iterable
+from typing import List, Union, Iterable, Tuple
 
 import jsonlines
 from spacy.language import Language
@@ -14,12 +14,18 @@ from conspiracies.docprocessing.relationextraction.gptprompting import (
 )
 
 
-def _doc_to_json(doc: Doc):
+def _doc_to_json(doc: Doc | Tuple[Doc, str]):
+    if isinstance(doc, Tuple):
+        doc, id_ = doc
+    else:
+        id_ = None
     if Doc.has_extension("relation_triplets"):
         triplets = doc._.relation_triplets
     else:
         triplets = []
     json = doc.to_json()
+    if id_ is not None:
+        json["id"] = id_
     json["semantic_triplets"] = [
         triplet.to_dict(include_doc=False) for triplet in triplets
     ]
@@ -39,7 +45,7 @@ def _doc_from_json(json: dict, nlp: Language) -> Doc:
 
 
 def docs_to_jsonl(
-    docs: Iterable[Doc],
+    docs: Iterable[Doc | Tuple[Doc, str]],
     path: Union[Path, str],
     append=False,
 ) -> None:

--- a/src/conspiracies/docprocessing/doc_utils.py
+++ b/src/conspiracies/docprocessing/doc_utils.py
@@ -14,7 +14,7 @@ from conspiracies.docprocessing.relationextraction.gptprompting import (
 )
 
 
-def _doc_to_json(doc: Doc | Tuple[Doc, str]):
+def _doc_to_json(doc: Union[Doc | Tuple[Doc, str]], include_span_heads=True):
     if isinstance(doc, Tuple):
         doc, id_ = doc
     else:
@@ -27,7 +27,7 @@ def _doc_to_json(doc: Doc | Tuple[Doc, str]):
     if id_ is not None:
         json["id"] = id_
     json["semantic_triplets"] = [
-        triplet.to_dict(include_doc=False, include_span_heads=True)
+        triplet.to_dict(include_doc=False, include_span_heads=include_span_heads)
         for triplet in triplets
     ]
     return json
@@ -49,6 +49,7 @@ def docs_to_jsonl(
     docs: Iterable[Doc | Tuple[Doc, str]],
     path: Union[Path, str],
     append=False,
+    include_span_heads=True,
 ) -> None:
     """Write docs and triplets to a jsonl file.
 
@@ -59,7 +60,9 @@ def docs_to_jsonl(
         append: whether to append to file instead of overwriting
     """
     with jsonlines.open(path, "a" if append else "w") as writer:
-        writer.write_all(_doc_to_json(doc) for doc in docs)
+        writer.write_all(
+            _doc_to_json(doc, include_span_heads=include_span_heads) for doc in docs
+        )
 
 
 def docs_from_jsonl(

--- a/src/conspiracies/docprocessing/doc_utils.py
+++ b/src/conspiracies/docprocessing/doc_utils.py
@@ -14,7 +14,7 @@ from conspiracies.docprocessing.relationextraction.gptprompting import (
 )
 
 
-def _doc_to_json(doc: Union[Doc | Tuple[Doc, str]], include_span_heads=True):
+def _doc_to_json(doc: Union[Doc, Tuple[Doc, str]], include_span_heads=True):
     if isinstance(doc, Tuple):
         doc, id_ = doc
     else:
@@ -46,7 +46,7 @@ def _doc_from_json(json: dict, nlp: Language) -> Doc:
 
 
 def docs_to_jsonl(
-    docs: Iterable[Doc | Tuple[Doc, str]],
+    docs: Iterable[Doc, Tuple[Doc, str]],
     path: Union[Path, str],
     append=False,
     include_span_heads=True,

--- a/src/conspiracies/docprocessing/doc_utils.py
+++ b/src/conspiracies/docprocessing/doc_utils.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Union
+from typing import List, Union, Iterable
 
 import jsonlines
 from spacy.language import Language
@@ -39,7 +39,7 @@ def _doc_from_json(json: dict, nlp: Language) -> Doc:
 
 
 def docs_to_jsonl(
-    docs: List[Doc],
+    docs: Iterable[Doc],
     path: Union[Path, str],
 ) -> None:
     """Write docs and triplets to a jsonl file.
@@ -49,9 +49,8 @@ def docs_to_jsonl(
             "relation_triplets", the triplets will written to the jsonl file.
         path: path to the jsonl file.
     """
-    jsonl = [_doc_to_json(doc) for doc in docs]
     with jsonlines.open(path, "w") as writer:
-        writer.write_all(jsonl)
+        writer.write_all(_doc_to_json(doc) for doc in docs)
 
 
 def docs_from_jsonl(

--- a/src/conspiracies/docprocessing/doc_utils.py
+++ b/src/conspiracies/docprocessing/doc_utils.py
@@ -41,6 +41,7 @@ def _doc_from_json(json: dict, nlp: Language) -> Doc:
 def docs_to_jsonl(
     docs: Iterable[Doc],
     path: Union[Path, str],
+    append=False,
 ) -> None:
     """Write docs and triplets to a jsonl file.
 
@@ -48,8 +49,9 @@ def docs_to_jsonl(
         docs: a list of docs. If the docs have the extension
             "relation_triplets", the triplets will written to the jsonl file.
         path: path to the jsonl file.
+        append: whether to append to file instead of overwriting
     """
-    with jsonlines.open(path, "w") as writer:
+    with jsonlines.open(path, "a" if append else "w") as writer:
         writer.write_all(_doc_to_json(doc) for doc in docs)
 
 

--- a/src/conspiracies/docprocessing/doc_utils.py
+++ b/src/conspiracies/docprocessing/doc_utils.py
@@ -46,7 +46,7 @@ def _doc_from_json(json: dict, nlp: Language) -> Doc:
 
 
 def docs_to_jsonl(
-    docs: Iterable[Doc, Tuple[Doc, str]],
+    docs: Iterable[Union[Doc, Tuple[Doc, str]]],
     path: Union[Path, str],
     append=False,
     include_span_heads=True,
@@ -58,6 +58,8 @@ def docs_to_jsonl(
             "relation_triplets", the triplets will written to the jsonl file.
         path: path to the jsonl file.
         append: whether to append to file instead of overwriting
+        include_span_heads: whether to output an "extracted_head" field in the JSON
+            output from :class:`HeadWordExtractionComponent`
     """
     with jsonlines.open(path, "a" if append else "w") as writer:
         writer.write_all(

--- a/src/conspiracies/docprocessing/docprocessor.py
+++ b/src/conspiracies/docprocessing/docprocessor.py
@@ -82,10 +82,10 @@ class DocProcessor:
             #  on at the moment, so just make it work
             with jsonlines.open(output_path) as annotated_docs:
                 already_processed = {
-                    annotated_doc["text"] for annotated_doc in annotated_docs
+                    annotated_doc["text"].strip() for annotated_doc in annotated_docs
                 }
             print(f"Skipping {len(already_processed)} processed docs.")
-            docs = (doc for doc in docs if doc["text"] not in already_processed)
+            docs = (doc for doc in docs if doc["text"].strip() not in already_processed)
 
         # The coreference pipeline tends to choke on too large batches because of an
         # extreme memory pressure, hence the small batch size

--- a/src/conspiracies/docprocessing/docprocessor.py
+++ b/src/conspiracies/docprocessing/docprocessor.py
@@ -1,6 +1,7 @@
 from typing import Iterable
 
 import spacy
+from jsonlines import jsonlines
 from tqdm import tqdm
 
 from conspiracies import docs_to_jsonl
@@ -76,12 +77,16 @@ class DocProcessor:
         output_path: str,
         continue_from_last=False,
     ):
-        # if continue_from_last:
-        #     with jsonlines.open(output_path) as annotated_docs:
-        #         already_processed = {annotated_doc["id"]
-        #                              for annotated_doc in annotated_docs}
-        #     print(f"Skipping {len(already_processed)} processed docs.")
-        #     docs = (doc for doc in docs if doc["id"] not in already_processed)
+        if continue_from_last:
+            # TODO: this check should definitely not be with text, but ID is not passed
+            #  on at the moment, so just make it work
+            with jsonlines.open(output_path) as annotated_docs:
+                already_processed = {
+                    annotated_doc["text"].strip() for annotated_doc in annotated_docs
+                }
+            print(f"Skipping {len(already_processed)} processed docs.")
+            docs = (doc for doc in docs if doc["text"] not in already_processed)
+
         # The coreference pipeline tends to choke on too large batches because of an
         # extreme memory pressure, hence the small batch size
         coref_resolved_docs = self.coref_pipeline.pipe(

--- a/src/conspiracies/docprocessing/docprocessor.py
+++ b/src/conspiracies/docprocessing/docprocessor.py
@@ -1,0 +1,82 @@
+from typing import Iterable
+
+import spacy
+from tqdm import tqdm
+
+from conspiracies import docs_to_jsonl
+from conspiracies.document import Document, text_with_context, remove_context
+
+
+class DocProcessor:
+    def _build_coref_pipeline(self):
+        nlp_coref = spacy.blank("da")
+        nlp_coref.add_pipe("sentencizer")
+        nlp_coref.add_pipe("allennlp_coref")
+
+        def warn_error(proc_name, proc, docs, e):
+            print(
+                f"An error occurred when applying component {proc_name}. "
+                f"{[d[:20] + '...' for d in docs]}. {e}",
+            )
+
+        nlp_coref.set_error_handler(warn_error)
+        return nlp_coref
+
+    def _build_triplet_extraction_pipeline(self):
+        nlp = spacy.load("da_core_news_sm")
+        nlp.add_pipe(
+            "heads_extraction",
+            config={"normalize_to_entity": True, "normalize_to_noun_chunk": True},
+        )
+        # TODO: Any and only (!) relevant configuration from pipeline config should
+        #  trickle down to configuration of individual components here. For now, this
+        #  is just copy-pasta from elsewhere.
+        if self.triplet_extraction_component.lower() == "multi2oie":
+            config = {"confidence_threshold": 2.7, "model_args": {"batch_size": 10}}
+            nlp.add_pipe("relation_extractor", config=config)
+        elif self.triplet_extraction_component.lower() == "prompting":
+            config = {
+                "prompt_template": "conspiracies/template_1",
+                "examples": None,
+                "task_description": None,
+                "model_name": "text-davinci-002",
+                "backend": "conspiracies/openai_gpt3_api",
+                "api_key": "",
+                "split_doc_fn": None,
+                "api_kwargs": {
+                    "max_tokens": 500,
+                    "temperature": 0.7,
+                    "top_p": 1,
+                    "frequency_penalty": 0,
+                    "presence_penalty": 0,
+                },
+                "force": True,
+            }
+
+            nlp.add_pipe(
+                "conspiracies/prompt_relation_extraction",
+                last=True,
+                config=config,
+            )
+        else:
+            ValueError(
+                f"{self.triplet_extraction_component} is not a valid triplet "
+                f"relation extraction component.",
+            )
+        return nlp
+
+    def __init__(self, triplet_extraction="multi2oie"):
+        self.coref_pipeline = self._build_coref_pipeline()
+        self.triplet_extraction_component = triplet_extraction
+        self.triplet_extraction_pipeline = self._build_triplet_extraction_pipeline()
+
+    def process_docs(self, docs: Iterable[Document], output_path: str):
+        coref_resolved_docs = self.coref_pipeline.pipe(
+            text_with_context(doc) for doc in docs
+        )
+
+        with_triplets = self.triplet_extraction_pipeline.pipe(
+            remove_context(doc._.resolve_coref) for doc in coref_resolved_docs
+        )
+
+        docs_to_jsonl(tqdm(d for d in with_triplets), output_path)

--- a/src/conspiracies/docprocessing/docprocessor.py
+++ b/src/conspiracies/docprocessing/docprocessor.py
@@ -82,7 +82,7 @@ class DocProcessor:
             #  on at the moment, so just make it work
             with jsonlines.open(output_path) as annotated_docs:
                 already_processed = {
-                    annotated_doc["text"].strip() for annotated_doc in annotated_docs
+                    annotated_doc["text"] for annotated_doc in annotated_docs
                 }
             print(f"Skipping {len(already_processed)} processed docs.")
             docs = (doc for doc in docs if doc["text"] not in already_processed)

--- a/src/conspiracies/docprocessing/headwordextraction/__init__.py
+++ b/src/conspiracies/docprocessing/headwordextraction/__init__.py
@@ -1,1 +1,4 @@
-from .headwordextraction_component import contains_ents  # noqa F401
+from .headwordextraction_component import (
+    contains_ents,  # noqa F401
+    create_headwords_component,  # noqa F401
+)

--- a/src/conspiracies/docprocessing/relationextraction/data_classes.py
+++ b/src/conspiracies/docprocessing/relationextraction/data_classes.py
@@ -279,13 +279,14 @@ class SpanTriplet(BaseModel):
         else:
             data = {}
         data["semantic_triplets"] = self.dict()
-        for attr_name in ("subject", "predicate", "object"):
-            attr = getattr(self, attr_name)
-            data["semantic_triplets"][attr_name] = self.span_to_json(attr)
-            if include_span_heads and Span.has_extension("most_common_ancestor"):
-                data["semantic_triplets"][attr_name][
-                    "extracted_head"
-                ] = attr._.most_common_ancestor.text
+        data["semantic_triplets"]["subject"] = self.span_to_json(self.subject)
+        data["semantic_triplets"]["predicate"] = self.span_to_json(self.predicate)
+        data["semantic_triplets"]["object"] = self.span_to_json(self.object)
+        if include_span_heads and Span.has_extension("most_common_ancestor"):
+            subject_head = self.subject._.most_common_ancestor.text
+            data["semantic_triplets"]["subject"]["head"] = subject_head
+            object_head = self.object._.most_common_ancestor.text
+            data["semantic_triplets"]["object"]["head"] = object_head
 
         return data
 

--- a/src/conspiracies/docprocessing/relationextraction/multi2oie/__init__.py
+++ b/src/conspiracies/docprocessing/relationextraction/multi2oie/__init__.py
@@ -1,2 +1,2 @@
 from .knowledge_triplets import KnowledgeTriplets  # noqa F401
-from .multi2oie_component import SpacyRelationExtractor  # noqa F401
+from .multi2oie_component import make_relation_extractor  # noqa F401

--- a/src/conspiracies/document.py
+++ b/src/conspiracies/document.py
@@ -6,3 +6,14 @@ class Document(TypedDict):
     metadata: dict
     text: str
     context: str
+
+
+CONTEXT_END_MARKER = "[CONTEXT_END]"
+
+
+def text_with_context(doc: Document) -> str:
+    return "\n".join([doc["context"], CONTEXT_END_MARKER, doc["text"]])
+
+
+def remove_context(text: str) -> str:
+    return text.split(CONTEXT_END_MARKER)[-1]

--- a/src/conspiracies/document.py
+++ b/src/conspiracies/document.py
@@ -1,17 +1,19 @@
-from typing import TypedDict
+from typing import TypedDict, Optional
 
 
 class Document(TypedDict):
     id: str
     metadata: dict
     text: str
-    context: str
+    context: Optional[str]
 
 
 CONTEXT_END_MARKER = "[CONTEXT_END]"
 
 
 def text_with_context(doc: Document) -> str:
+    if doc["context"] is None:
+        return doc["text"]
     return "\n".join([doc["context"], CONTEXT_END_MARKER, doc["text"]])
 
 

--- a/src/conspiracies/document.py
+++ b/src/conspiracies/document.py
@@ -16,4 +16,4 @@ def text_with_context(doc: Document) -> str:
 
 
 def remove_context(text: str) -> str:
-    return text.split(CONTEXT_END_MARKER)[-1]
+    return text.split(CONTEXT_END_MARKER)[-1].strip()

--- a/src/conspiracies/document.py
+++ b/src/conspiracies/document.py
@@ -1,0 +1,8 @@
+from typing import TypedDict
+
+
+class Document(TypedDict):
+    id: str
+    metadata: dict
+    text: str
+    context: str

--- a/src/conspiracies/pipeline/config.py
+++ b/src/conspiracies/pipeline/config.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+
+
+class ProjectConfig(BaseModel):
+    project_name: str
+    output_root: str
+    language: str
+
+
+class PreprocessingConfig(BaseModel):
+    input_path: str
+    doc_type: str
+
+
+class DocprocessingConfig(BaseModel):
+    triplet_extraction_method: str

--- a/src/conspiracies/pipeline/config.py
+++ b/src/conspiracies/pipeline/config.py
@@ -2,7 +2,7 @@ import toml
 from pydantic import BaseModel
 
 
-class ProjectConfig(BaseModel):
+class BaseConfig(BaseModel):
     project_name: str
     output_root: str
     language: str
@@ -12,23 +12,40 @@ class StepConfig(BaseModel):
     enabled: bool = True
 
 
-class PreprocessingConfig(StepConfig):
+class PreProcessingConfig(StepConfig):
     input_path: str
     doc_type: str
     extra: dict = {}
 
 
-class DocprocessingConfig(StepConfig):
+class DocProcessingConfig(StepConfig):
     triplet_extraction_method: str
 
 
+class CorpusProcessingConfig(StepConfig):
+    pass
+
+
 class PipelineConfig(BaseModel):
-    project: ProjectConfig
-    preprocessing: PreprocessingConfig
-    docprocessing: DocprocessingConfig
+    base: BaseConfig
+    preprocessing: PreProcessingConfig
+    docprocessing: DocProcessingConfig
+    corpusprocessing: CorpusProcessingConfig
+
+    @staticmethod
+    def update_nested_dict(d, path, value):
+        keys = path.split(".")
+        for key in keys[:-1]:
+            d = d.setdefault(key, {})
+        d[keys[-1]] = value
 
     @classmethod
-    def from_toml_file(cls, path: str):
+    def from_toml_file(cls, path: str, extra_config: dict = None):
         with open(path, "r") as file:
             config_data = toml.load(file)
+        if extra_config:
+            for path, value in extra_config.items():
+                if value is None:
+                    continue
+                PipelineConfig.update_nested_dict(config_data, path, value)
         return cls(**config_data)

--- a/src/conspiracies/pipeline/config.py
+++ b/src/conspiracies/pipeline/config.py
@@ -1,3 +1,4 @@
+import toml
 from pydantic import BaseModel
 
 
@@ -7,10 +8,27 @@ class ProjectConfig(BaseModel):
     language: str
 
 
-class PreprocessingConfig(BaseModel):
+class StepConfig(BaseModel):
+    enabled: bool = True
+
+
+class PreprocessingConfig(StepConfig):
     input_path: str
     doc_type: str
+    extra: dict = {}
 
 
-class DocprocessingConfig(BaseModel):
+class DocprocessingConfig(StepConfig):
     triplet_extraction_method: str
+
+
+class PipelineConfig(BaseModel):
+    project: ProjectConfig
+    preprocessing: PreprocessingConfig
+    docprocessing: DocprocessingConfig
+
+    @classmethod
+    def from_toml_file(cls, path: str):
+        with open(path, "r") as file:
+            config_data = toml.load(file)
+        return cls(**config_data)

--- a/src/conspiracies/pipeline/config.py
+++ b/src/conspiracies/pipeline/config.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import toml
 from pydantic import BaseModel
 
@@ -33,7 +35,18 @@ class PipelineConfig(BaseModel):
     corpusprocessing: CorpusProcessingConfig
 
     @staticmethod
-    def update_nested_dict(d, path, value):
+    def update_nested_dict(d: dict[str, Any], path: str, value: Any) -> None:
+        """Sets or updates a nested dict in place with a TOML-like string key.
+
+        >>> some_dict = {"a": {"b": 1}}
+        >>> PipelineConfig.update_nested_dict(some_dict, "a.b", 2)
+        >>> some_dict["a"]["b"] == 2  # True
+
+        Args:
+            d: (nested) dict with str keys to be updated
+            path: a TOML-like string key with '.' as level separators, e.g. "a.b.c"
+            value: value to set under the nested key
+        """
         keys = path.split(".")
         for key in keys[:-1]:
             d = d.setdefault(key, {})

--- a/src/conspiracies/pipeline/config.py
+++ b/src/conspiracies/pipeline/config.py
@@ -17,6 +17,7 @@ class StepConfig(BaseModel):
 class PreProcessingConfig(StepConfig):
     input_path: str
     doc_type: str
+    metadata_fields: set[str]
     extra: dict = {}
 
 

--- a/src/conspiracies/pipeline/pipeline.py
+++ b/src/conspiracies/pipeline/pipeline.py
@@ -8,6 +8,7 @@ from conspiracies.document import Document
 from conspiracies.pipeline.config import PipelineConfig
 from conspiracies.preprocessing.infomedia import InfoMediaPreprocessor
 from conspiracies.preprocessing.preprocessor import Preprocessor
+from conspiracies.preprocessing.text import TextFilePreprocessor
 from conspiracies.preprocessing.tweets import TweetsPreprocessor
 from conspiracies.visualization.graph import create_network_graph, get_nodes_edges
 
@@ -34,11 +35,17 @@ class Pipeline:
             self.corpusprocessing()
 
     def _get_preprocessor(self) -> Preprocessor:
-        doc_type = self.config.preprocessing.doc_type.lower()
-        if doc_type == "tweets":
-            return TweetsPreprocessor(**self.config.preprocessing.extra)
+        config = self.config.preprocessing
+        doc_type = config.doc_type.lower()
+        if doc_type == "text":
+            return TextFilePreprocessor(**config.extra)
+        elif doc_type == "tweets":
+            return TweetsPreprocessor(
+                metadata_fields=config.metadata_fields,
+                **config.extra,
+            )
         elif doc_type == "infomedia":
-            return InfoMediaPreprocessor(**self.config.preprocessing.extra)
+            return InfoMediaPreprocessor(metadata_fields=config.metadata_fields)
         else:
             raise ValueError(
                 f"Unknown document type: {doc_type}. "
@@ -63,10 +70,10 @@ class Pipeline:
             (
                 json.loads(line, object_hook=Document)
                 for line in iter_lines_of_files(
-                    f"output/{self.project_name}/preprocessed.ndjson",
+                    f"{self.output_path}/preprocessed.ndjson",
                 )
             ),
-            f"output/{self.project_name}/annotations.ndjson",
+            f"{self.output_path}/annotations.ndjson",
             continue_from_last=continue_from_last,
         )
 

--- a/src/conspiracies/pipeline/pipeline.py
+++ b/src/conspiracies/pipeline/pipeline.py
@@ -6,6 +6,7 @@ from conspiracies.corpusprocessing import umap_hdb
 from conspiracies.docprocessing.docprocessor import DocProcessor
 from conspiracies.document import Document
 from conspiracies.pipeline.config import PipelineConfig
+from conspiracies.preprocessing.csv import CsvPreprocessor
 from conspiracies.preprocessing.infomedia import InfoMediaPreprocessor
 from conspiracies.preprocessing.preprocessor import Preprocessor
 from conspiracies.preprocessing.text import TextFilePreprocessor
@@ -39,6 +40,11 @@ class Pipeline:
         doc_type = config.doc_type.lower()
         if doc_type == "text":
             return TextFilePreprocessor(**config.extra)
+        if doc_type == "csv":
+            return CsvPreprocessor(
+                metadata_fields=config.metadata_fields,
+                **config.extra,
+            )
         elif doc_type == "tweets":
             return TweetsPreprocessor(
                 metadata_fields=config.metadata_fields,

--- a/src/conspiracies/pipeline/runner.py
+++ b/src/conspiracies/pipeline/runner.py
@@ -1,9 +1,89 @@
-class Runner:
-    def preprocessing(self):
-        pass
+import glob
+import json
 
-    def docprocessing(self):
-        pass
+from conspiracies.corpusprocessing import umap_hdb
+from conspiracies.docprocessing.docprocessor import DocProcessor
+from conspiracies.document import Document
+from conspiracies.pipeline.config import (
+    ProjectConfig,
+    PreprocessingConfig,
+    DocprocessingConfig,
+)
+from conspiracies.preprocessing.infomedia import InfoMediaPreprocessor
+from conspiracies.preprocessing.preprocessor import Preprocessor
+from conspiracies.preprocessing.tweets import TweetsPreprocessor
+
+
+def iter_lines_of_files(glob_pattern: str):
+    files = glob.glob(glob_pattern, recursive=True)
+    for file in files:
+        with open(file) as f:
+            for line in f:
+                yield line
+
+
+class Runner:
+    project_config: ProjectConfig
+    preprocessing_config: PreprocessingConfig
+    docprocessing_config: DocprocessingConfig
+
+    def _get_preprocessor(self) -> Preprocessor:
+        doc_type = self.preprocessing_config.doc_type.lower()
+        if doc_type == "tweets":
+            return TweetsPreprocessor(self.project_config.project_name)
+        elif doc_type == "infomedia":
+            return InfoMediaPreprocessor(self.project_config.project_name)
+        else:
+            raise ValueError(
+                f"Unknown document type: {doc_type}. "
+                f"Available types are: tweets, infomedia",
+            )
+
+    def preprocessing(self) -> None:
+        preprocessor = self._get_preprocessor()
+        preprocessor.preprocess_docs(self.preprocessing_config.input_path)
+
+    def _get_docprocessor(self) -> DocProcessor:
+        return DocProcessor(
+            triplet_extraction=self.docprocessing_config.triplet_extraction_method,
+        )
+
+    def docprocessing(self, continue_from_last=False):
+        docprocessor = self._get_docprocessor()
+        docprocessor.process_docs(
+            (
+                json.loads(line, object_hook=Document)
+                for line in iter_lines_of_files(
+                    f"output/{self.project_config.project_name}/preprocessed.ndjson",
+                )
+            ),
+            f"output/{self.project_config.project_name}/annotations.ndjson",
+            continue_from_last=continue_from_last,
+        )
 
     def corpusprocessing(self):
-        pass
+        # TODO: this is kind of dumb, but for now just make it work
+        docs = (
+            json.loads(line)
+            for line in iter_lines_of_files(
+                f"output/{self.project_config.project_name}/annotations.ndjson",
+            )
+        )
+        with open(
+            f"output/{self.project_config.project_name}/triplets.csv",
+            "w+",
+        ) as out:
+            for doc in docs:
+                for triplet in doc["semantic_triplets"]:
+                    print(
+                        ", ".join(
+                            triplet["semantic_triplets"][field]["text"]
+                            for field in ("subject", "predicate", "object")
+                        ),
+                        file=out,
+                    )
+        umap_hdb.main(
+            f"output/{self.project_config.project_name}/triplets.csv",
+            "danskBERT",
+            save=f"output/{self.project_config.project_name}/clusters.json",
+        )

--- a/src/conspiracies/pipeline/runner.py
+++ b/src/conspiracies/pipeline/runner.py
@@ -1,0 +1,9 @@
+class Runner:
+    def preprocessing(self):
+        pass
+
+    def docprocessing(self):
+        pass
+
+    def corpusprocessing(self):
+        pass

--- a/src/conspiracies/preprocessing/create_context_threads.py
+++ b/src/conspiracies/preprocessing/create_context_threads.py
@@ -66,9 +66,7 @@ def context_window_thread(tweets, context_len):
 
     # find the context for each tweet in the conversation and return the contexts that are longer than 1 tweet
     contexts = [
-        find_context(tweet, conversations[tweet["conversation_id"]])
-        for tweet in tweets
-        if len(find_context(tweet, conversations[tweet["conversation_id"]])) > 1
+        find_context(tweet, conversations[tweet["conversation_id"]]) for tweet in tweets
     ]
     return contexts
 

--- a/src/conspiracies/preprocessing/csv.py
+++ b/src/conspiracies/preprocessing/csv.py
@@ -1,0 +1,48 @@
+import csv
+from typing import Iterable, Iterator
+
+from conspiracies.common.fileutils import iter_lines_of_files
+from conspiracies.document import Document
+from conspiracies.preprocessing.preprocessor import Preprocessor
+
+
+class CsvPreprocessor(Preprocessor):
+
+    def __init__(
+        self,
+        id_column: str = None,
+        text_column: str = None,
+        context_column: str = None,
+        delimiter=",",
+        metadata_fields: Iterable[str] = ("*",),
+    ):
+        self.id_column = id_column
+        self.text_column = text_column
+        self.context_column = context_column
+        self.non_metadata_columns = {
+            self.id_column,
+            self.text_column,
+            self.context_column,
+        }
+        self.delimiter = delimiter
+        super().__init__(metadata_fields=metadata_fields)
+
+    def _read_lines(self, lines: Iterable[str]) -> Iterator[str]:
+        reader = csv.DictReader(lines, delimiter=self.delimiter)
+        for row in reader:  # type: dict
+            id_ = row[self.id_column]
+            text = row[self.text_column]
+            context = row[self.context_column] if self.context_column else None
+            metadata = {
+                k: v for k, v in row.items() if k not in self.non_metadata_columns
+            }
+            yield Document(
+                id=id_,
+                text=text,
+                context=context,
+                metadata=metadata,
+            )
+
+    def _do_preprocess_docs(self, input_path: str) -> Iterator[str]:
+        lines = iter_lines_of_files(input_path)
+        return self._read_lines(lines)

--- a/src/conspiracies/preprocessing/infomedia.py
+++ b/src/conspiracies/preprocessing/infomedia.py
@@ -1,0 +1,60 @@
+import json
+import multiprocessing.pool
+
+import bs4
+
+from conspiracies.document import Document
+from conspiracies.preprocessing.preprocessor import Preprocessor
+
+
+class InfoMediaPreprocessor(Preprocessor):
+    METADATA_KEYS = {
+        "ArticleUrl",
+        "Authors",
+        "Heading",
+        "Lead",
+        "PageIds",
+        "PublishDate",
+        "Section",
+        "Source",
+        "WordCount",
+    }
+
+    def do_preprocess_docs(self, glob_pattern: str):
+        lines = Preprocessor.iter_lines_of_files(glob_pattern)
+        if self.n_cores > 1:
+            with multiprocessing.pool.Pool(processes=self.n_cores) as p:
+                for result in p.imap_unordered(self.process_line, lines, chunksize=100):
+                    yield result
+        else:
+            for line in lines:
+                yield self.process_line(line)
+
+    def process_line(self, line: str):
+        obj = json.loads(line)
+
+        doc_id = obj["ArticleId"]
+        metadata = {k: obj[k] for k in InfoMediaPreprocessor.METADATA_KEYS}
+        text = self.create_text(obj)
+
+        return Document(id=doc_id, metadata=metadata, text=text, context=None)
+
+    @staticmethod
+    def create_text(doc_obj: dict):
+        text_pieces = [doc_obj["Heading"] + "\n"]
+
+        subheading = doc_obj["SubHeading"]
+        if subheading:
+            text_pieces.append(subheading + "\n")
+
+        body = bs4.BeautifulSoup(doc_obj["BodyText"], features="html.parser")
+        paragraphs = body.find_all("p")
+        for paragraph in paragraphs:
+            paragraph_pieces = []
+            for child in paragraph:
+                if child.name == "br":
+                    paragraph_pieces.append("\n")
+                else:
+                    paragraph_pieces.append(child.get_text())
+            text_pieces.append("".join(paragraph_pieces))
+        return "\n".join(text_pieces).strip()

--- a/src/conspiracies/preprocessing/infomedia.py
+++ b/src/conspiracies/preprocessing/infomedia.py
@@ -1,8 +1,8 @@
 import json
-import multiprocessing.pool
 
 import bs4
 
+from conspiracies.common.fileutils import iter_lines_of_files
 from conspiracies.document import Document
 from conspiracies.preprocessing.preprocessor import Preprocessor
 
@@ -20,15 +20,10 @@ class InfoMediaPreprocessor(Preprocessor):
         "WordCount",
     }
 
-    def do_preprocess_docs(self, glob_pattern: str):
-        lines = Preprocessor.iter_lines_of_files(glob_pattern)
-        if self.n_cores > 1:
-            with multiprocessing.pool.Pool(processes=self.n_cores) as p:
-                for result in p.imap_unordered(self.process_line, lines, chunksize=100):
-                    yield result
-        else:
-            for line in lines:
-                yield self.process_line(line)
+    def _do_preprocess_docs(self, glob_pattern: str):
+        lines = iter_lines_of_files(glob_pattern)
+        for line in lines:
+            yield self.process_line(line)
 
     def process_line(self, line: str):
         obj = json.loads(line)

--- a/src/conspiracies/preprocessing/preprocessor.py
+++ b/src/conspiracies/preprocessing/preprocessor.py
@@ -1,3 +1,4 @@
+import logging
 import os.path
 from os import path
 import glob
@@ -38,6 +39,7 @@ class Preprocessor:
             if len(batch) == self.batch_size:
                 self.output_batch(batch)
                 batch.clear()
+        self.output_batch(batch)
 
     def output_batch(self, batch: List[Document]):
         filepath = path.join(
@@ -52,6 +54,11 @@ class Preprocessor:
     @staticmethod
     def iter_lines_of_files(glob_pattern: str):
         files = glob.glob(glob_pattern, recursive=True)
+        logging.info(
+            "The glob pattern '%s' resulted in the following files: %s",
+            glob_pattern,
+            files,
+        )
         for file in files:
             with open(file) as f:
                 for line in f:

--- a/src/conspiracies/preprocessing/preprocessor.py
+++ b/src/conspiracies/preprocessing/preprocessor.py
@@ -33,13 +33,13 @@ class Preprocessor:
     def output_preprocessed_docs(self, preprocessed_docs: Iterator[Document]) -> None:
         p = path.join(self.output_folder, self.project_name)
         os.makedirs(p, exist_ok=True)
-        batch = []
-        for d in preprocessed_docs:
-            batch.append(d)
-            if len(batch) == self.batch_size:
-                self.output_batch(batch)
-                batch.clear()
-        self.output_batch(batch)
+        filepath = path.join(
+            self.output_folder,
+            self.project_name,
+            "preprocessed.ndjson",
+        )
+        with open(filepath, "w+") as out_file:
+            ndjson.dump(preprocessed_docs, out_file)
 
     def output_batch(self, batch: List[Document]):
         filepath = path.join(

--- a/src/conspiracies/preprocessing/preprocessor.py
+++ b/src/conspiracies/preprocessing/preprocessor.py
@@ -1,8 +1,4 @@
-import logging
-import os.path
-from os import path
-import glob
-from typing import List, Iterator
+from typing import Iterator
 
 import ndjson
 
@@ -10,56 +6,13 @@ from conspiracies.document import Document
 
 
 class Preprocessor:
-    def __init__(
-        self,
-        project_name: str,
-        output_folder: str = "output",
-        n_cores: int = 1,
-        batch_size=10000,
-    ):
-        self.project_name = project_name
-        self.output_folder = output_folder
+    def __init__(self, n_cores: int = 1):
         self.n_cores = n_cores
-        self.batch_size = batch_size
-        self.at_batch = 0
 
-    def preprocess_docs(self, *args):
-        preprocessed_docs = self.do_preprocess_docs(*args)
-        self.output_preprocessed_docs(preprocessed_docs)
+    def preprocess_docs(self, input_path: str, output_path: str, *args):
+        preprocessed_docs = self.do_preprocess_docs(input_path)
+        with open(output_path, "w+") as out_file:
+            ndjson.dump(preprocessed_docs, out_file)
 
     def do_preprocess_docs(self, *args) -> Iterator[Document]:
         pass
-
-    def output_preprocessed_docs(self, preprocessed_docs: Iterator[Document]) -> None:
-        p = path.join(self.output_folder, self.project_name)
-        os.makedirs(p, exist_ok=True)
-        filepath = path.join(
-            self.output_folder,
-            self.project_name,
-            "preprocessed.ndjson",
-        )
-        with open(filepath, "w+") as out_file:
-            ndjson.dump(preprocessed_docs, out_file)
-
-    def output_batch(self, batch: List[Document]):
-        filepath = path.join(
-            self.output_folder,
-            self.project_name,
-            f"part{self.at_batch}.ndjson",
-        )
-        with open(filepath, "w+") as out_file:
-            ndjson.dump(batch, out_file)
-        self.at_batch += 1
-
-    @staticmethod
-    def iter_lines_of_files(glob_pattern: str):
-        files = glob.glob(glob_pattern, recursive=True)
-        logging.info(
-            "The glob pattern '%s' resulted in the following files: %s",
-            glob_pattern,
-            files,
-        )
-        for file in files:
-            with open(file) as f:
-                for line in f:
-                    yield line

--- a/src/conspiracies/preprocessing/preprocessor.py
+++ b/src/conspiracies/preprocessing/preprocessor.py
@@ -1,0 +1,58 @@
+import os.path
+from os import path
+import glob
+from typing import List, Iterator
+
+import ndjson
+
+from conspiracies.document import Document
+
+
+class Preprocessor:
+    def __init__(
+        self,
+        project_name: str,
+        output_folder: str = "output",
+        n_cores: int = 1,
+        batch_size=10000,
+    ):
+        self.project_name = project_name
+        self.output_folder = output_folder
+        self.n_cores = n_cores
+        self.batch_size = batch_size
+        self.at_batch = 0
+
+    def preprocess_docs(self, *args):
+        preprocessed_docs = self.do_preprocess_docs(*args)
+        self.output_preprocessed_docs(preprocessed_docs)
+
+    def do_preprocess_docs(self, *args) -> Iterator[Document]:
+        pass
+
+    def output_preprocessed_docs(self, preprocessed_docs: Iterator[Document]) -> None:
+        p = path.join(self.output_folder, self.project_name)
+        os.makedirs(p, exist_ok=True)
+        batch = []
+        for d in preprocessed_docs:
+            batch.append(d)
+            if len(batch) == self.batch_size:
+                self.output_batch(batch)
+                batch.clear()
+
+    def output_batch(self, batch: List[Document]):
+        filepath = path.join(
+            self.output_folder,
+            self.project_name,
+            f"part{self.at_batch}.ndjson",
+        )
+        with open(filepath, "w+") as out_file:
+            ndjson.dump(batch, out_file)
+        self.at_batch += 1
+
+    @staticmethod
+    def iter_lines_of_files(glob_pattern: str):
+        files = glob.glob(glob_pattern, recursive=True)
+        for file in files:
+            with open(file) as f:
+                for line in f:
+                    yield line

--- a/src/conspiracies/preprocessing/text.py
+++ b/src/conspiracies/preprocessing/text.py
@@ -1,0 +1,25 @@
+import glob
+import os.path
+
+from conspiracies.document import Document
+from conspiracies.preprocessing.preprocessor import Preprocessor
+
+
+class TextFilePreprocessor(Preprocessor):
+
+    def __init__(self, basename_as_id=True):
+        super().__init__()
+        self.basename_as_id = basename_as_id
+
+    def _do_preprocess_docs(self, glob_pattern: str):
+        files = glob.glob(glob_pattern, recursive=True)
+        for file in files:
+            id_ = os.path.basename(file) if self.basename_as_id else file
+            with open(file) as in_file:
+                text = in_file.read()
+            yield Document(
+                id=id_,
+                text=text,
+                metadata={},
+                context=None,
+            )

--- a/src/conspiracies/preprocessing/tweets.py
+++ b/src/conspiracies/preprocessing/tweets.py
@@ -1,6 +1,6 @@
 import json
 import logging
-import multiprocessing.pool
+from typing import Iterable
 
 from conspiracies.common.fileutils import iter_lines_of_files
 from conspiracies.document import Document
@@ -8,44 +8,25 @@ from conspiracies.preprocessing.create_context_threads import context_window_thr
 from conspiracies.preprocessing.preprocessor import Preprocessor
 
 # TODO: Due to the way contexts are found and handled which requires all tweets to be
-#  loaded in memory, this is not gonna scale very well for large datasets. At the
-#  moment, contexts are found by only loading what is needed for the contexts, i.e.
-#  less metadata, and then outputting that, and handling metadata on its own. That
-#  means two data passes though.
-#  It must be possible to avoid having it all in memory, e.g. a join operation in
-#  Pandas or Spark. Can we avoid two data-passes in that case?
+#  loaded in memory, this is not gonna scale very well for large datasets.
 
 
 class TweetsPreprocessor(Preprocessor):
-    CONTENT_FIELDS = {
-        "id",
-        "conversation_id",
-        "referenced_tweets",
-        "text",
-        "in_reply_to_user_id",
-    }
 
     def __init__(
         self,
-        n_cores: int = 1,
-        context_len: int = 2,
+        metadata_fields: Iterable[str] = ("*",),
+        context_length: int = 2,
     ):
-        super().__init__(n_cores=n_cores)
-        self.context_len = context_len
+        super().__init__(metadata_fields=metadata_fields)
+        self.context_length = context_length
 
-    def do_preprocess_docs(self, glob_pattern: str):
+    def _do_preprocess_docs(self, glob_pattern: str):
         lines = iter_lines_of_files(glob_pattern)
-        tweets = []
-        if self.n_cores > 1:
-            with multiprocessing.pool.Pool(processes=self.n_cores) as p:
-                for result in p.imap_unordered(json.loads, lines, chunksize=100):
-                    tweets.append(result)
-        else:
-            for line in lines:
-                tweets.append(json.loads(line))
+        tweets = [json.loads(line) for line in lines]
 
         doc_ids = set()
-        tweets_with_context = context_window_thread(tweets, self.context_len)
+        tweets_with_context = context_window_thread(tweets, self.context_length)
         for tweet_with_context in tweets_with_context:
             context_tweets, tweet = tweet_with_context[:-1], tweet_with_context[-1]
             doc_id = tweet["id"]

--- a/src/conspiracies/preprocessing/tweets.py
+++ b/src/conspiracies/preprocessing/tweets.py
@@ -1,0 +1,54 @@
+import json
+import multiprocessing.pool
+
+from conspiracies.document import Document
+from conspiracies.preprocessing.create_context_threads import context_window_thread
+from conspiracies.preprocessing.preprocessor import Preprocessor
+
+# TODO: Due to the way contexts are found and handled which requires all tweets to be
+#  loaded in memory, this is not gonna scale very well for large datasets. At the
+#  moment, contexts are found by only loading what is needed for the contexts, i.e.
+#  less metadata, and then outputting that, and handling metadata on its own. That
+#  means two data passes though.
+#  It must be possible to avoid having it all in memory, e.g. a join operation in
+#  Pandas or Spark. Can we avoid two data-passes in that case?
+
+
+class TweetsPreprocessor(Preprocessor):
+    CONTENT_FIELDS = {
+        "id",
+        "conversation_id",
+        "referenced_tweets",
+        "text",
+        "in_reply_to_user_id",
+    }
+
+    def __init__(
+        self,
+        project_name: str,
+        context_len: int = 2,
+        output_folder: str = "output",
+        n_cores: int = 1,
+    ):
+        super().__init__(project_name, output_folder=output_folder, n_cores=n_cores)
+        self.context_len = context_len
+
+    def do_preprocess_docs(self, glob_pattern: str):
+        lines = Preprocessor.iter_lines_of_files(glob_pattern)
+        tweets = []
+        if self.n_cores > 1:
+            with multiprocessing.pool.Pool(processes=self.n_cores) as p:
+                for result in p.imap_unordered(json.loads, lines, chunksize=100):
+                    tweets.append(result)
+        else:
+            for line in lines:
+                tweets.append(json.loads(line))
+
+        tweets_with_context = context_window_thread(tweets, self.context_len)
+        for tweet_with_context in tweets_with_context:
+            context_tweets, tweet = tweet_with_context[:-1], tweet_with_context[-1]
+            doc_id = tweet["id"]
+            metadata = {k: v for k, v in tweet.items() if k != "text"}
+            text = tweet["text"]
+            context = "\n".join(t["text"] for t in context_tweets)
+            yield Document(id=doc_id, metadata=metadata, text=text, context=context)

--- a/src/conspiracies/preprocessing/tweets.py
+++ b/src/conspiracies/preprocessing/tweets.py
@@ -1,6 +1,7 @@
 import json
 import multiprocessing.pool
 
+from conspiracies.common.fileutils import iter_lines_of_files
 from conspiracies.document import Document
 from conspiracies.preprocessing.create_context_threads import context_window_thread
 from conspiracies.preprocessing.preprocessor import Preprocessor
@@ -25,16 +26,14 @@ class TweetsPreprocessor(Preprocessor):
 
     def __init__(
         self,
-        project_name: str,
-        context_len: int = 2,
-        output_folder: str = "output",
         n_cores: int = 1,
+        context_len: int = 2,
     ):
-        super().__init__(project_name, output_folder=output_folder, n_cores=n_cores)
+        super().__init__(n_cores=n_cores)
         self.context_len = context_len
 
     def do_preprocess_docs(self, glob_pattern: str):
-        lines = Preprocessor.iter_lines_of_files(glob_pattern)
+        lines = iter_lines_of_files(glob_pattern)
         tweets = []
         if self.n_cores > 1:
             with multiprocessing.pool.Pool(processes=self.n_cores) as p:

--- a/tests/test_csvpreprocessing.py
+++ b/tests/test_csvpreprocessing.py
@@ -1,0 +1,36 @@
+import pytest
+
+from conspiracies.document import Document
+from conspiracies.preprocessing.csv import CsvPreprocessor
+
+
+@pytest.fixture
+def csv_with_headers():
+    lines = [
+        "id,text,context,metadata1,metadata2",
+        "1,some text,a bit of context,one,two",
+    ]
+    return lines
+
+
+@pytest.fixture
+def expected_docs():
+    return [
+        Document(
+            id="1",
+            text="some text",
+            context="a bit of context",
+            metadata={"metadata1": "one", "metadata2": "two"},
+        ),
+    ]
+
+
+def test_read_lines(csv_with_headers, expected_docs):
+    preprocessor = CsvPreprocessor(
+        id_column="id",
+        text_column="text",
+        context_column="context",
+    )
+    # NOTE: metadata fields are not filtered in this method, so all other fields will be
+    #   included as metadata
+    assert list(preprocessor._read_lines(csv_with_headers)) == expected_docs

--- a/tests/test_data/test_config.toml
+++ b/tests/test_data/test_config.toml
@@ -6,6 +6,7 @@ language = "en"
 [preprocessing]
 enabled = false
 input_path = "some_input"
+metadata_fields = ["metadata_field"]
 doc_type = "test"
 
 [preprocessing.extra]

--- a/tests/test_data/test_config.toml
+++ b/tests/test_data/test_config.toml
@@ -1,0 +1,15 @@
+[project]
+project_name = "test"
+output_root = "output"
+language = "en"
+
+[preprocessing]
+enabled = false
+input_path = "some_input"
+doc_type = "test"
+
+[preprocessing.extra]
+some_extra_value = 1234
+
+[docprocessing]
+triplet_extraction_method = "test"

--- a/tests/test_data/test_config.toml
+++ b/tests/test_data/test_config.toml
@@ -1,4 +1,4 @@
-[project]
+[base]
 project_name = "test"
 output_root = "output"
 language = "en"
@@ -13,3 +13,5 @@ some_extra_value = 1234
 
 [docprocessing]
 triplet_extraction_method = "test"
+
+[corpusprocessing]

--- a/tests/test_infomedia_preprocessing.py
+++ b/tests/test_infomedia_preprocessing.py
@@ -1,0 +1,22 @@
+from conspiracies.preprocessing.infomedia import InfoMediaPreprocessor
+
+
+def test_create_text():
+    input_text = {
+        "Heading": "Nice title",
+        "SubHeading": "With a nice subtitle",
+        "BodyText": "<p>One paragraph</p>"
+        "<p>Another paragraph</p>"
+        "<p><br/>A third with a line break and <em>emphasis</em>.</p>",
+    }
+    text = InfoMediaPreprocessor.create_text(input_text)
+
+    expected = (
+        "Nice title\n\n"
+        "With a nice subtitle\n\n"
+        "One paragraph\n"
+        "Another paragraph\n\n"
+        "A third with a line break and emphasis."
+    )
+
+    assert text == expected

--- a/tests/test_pipelineconfig.py
+++ b/tests/test_pipelineconfig.py
@@ -1,20 +1,21 @@
 from conspiracies.pipeline.config import (
     PipelineConfig,
-    ProjectConfig,
-    PreprocessingConfig,
-    DocprocessingConfig,
+    BaseConfig,
+    PreProcessingConfig,
+    DocProcessingConfig,
+    CorpusProcessingConfig,
 )
 
 
 def test_config_loading():
     config = PipelineConfig.from_toml_file("test_data/test_config.toml")
     assert config == PipelineConfig(
-        project=ProjectConfig(
+        base=BaseConfig(
             project_name="test",
             output_root="output",
             language="en",
         ),
-        preprocessing=PreprocessingConfig(
+        preprocessing=PreProcessingConfig(
             enabled=False,
             input_path="some_input",
             doc_type="test",
@@ -22,7 +23,8 @@ def test_config_loading():
                 "some_extra_value": 1234,
             },
         ),
-        docprocessing=DocprocessingConfig(
+        docprocessing=DocProcessingConfig(
             triplet_extraction_method="test",
         ),
+        corpusprocessing=CorpusProcessingConfig(),
     )

--- a/tests/test_pipelineconfig.py
+++ b/tests/test_pipelineconfig.py
@@ -1,0 +1,28 @@
+from conspiracies.pipeline.config import (
+    PipelineConfig,
+    ProjectConfig,
+    PreprocessingConfig,
+    DocprocessingConfig,
+)
+
+
+def test_config_loading():
+    config = PipelineConfig.from_toml_file("test_data/test_config.toml")
+    assert config == PipelineConfig(
+        project=ProjectConfig(
+            project_name="test",
+            output_root="output",
+            language="en",
+        ),
+        preprocessing=PreprocessingConfig(
+            enabled=False,
+            input_path="some_input",
+            doc_type="test",
+            extra={
+                "some_extra_value": 1234,
+            },
+        ),
+        docprocessing=DocprocessingConfig(
+            triplet_extraction_method="test",
+        ),
+    )

--- a/tests/test_pipelineconfig.py
+++ b/tests/test_pipelineconfig.py
@@ -29,6 +29,7 @@ def test_config_loading(path: str):
             enabled=False,
             input_path="some_input",
             doc_type="test",
+            metadata_fields={"metadata_field"},
             extra={
                 "some_extra_value": 1234,
             },

--- a/tests/test_pipelineconfig.py
+++ b/tests/test_pipelineconfig.py
@@ -1,3 +1,7 @@
+from pathlib import Path
+
+import pytest
+
 from conspiracies.pipeline.config import (
     PipelineConfig,
     BaseConfig,
@@ -7,8 +11,14 @@ from conspiracies.pipeline.config import (
 )
 
 
-def test_config_loading():
-    config = PipelineConfig.from_toml_file("test_data/test_config.toml")
+@pytest.fixture()
+def path():
+    data_path = Path(__file__).parent / "test_data" / "test_config.toml"
+    return data_path
+
+
+def test_config_loading(path: str):
+    config = PipelineConfig.from_toml_file(path)
     assert config == PipelineConfig(
         base=BaseConfig(
             project_name="test",

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,0 +1,41 @@
+from typing import Iterator
+
+import pytest
+
+from conspiracies.document import Document
+from conspiracies.preprocessing.preprocessor import Preprocessor
+
+
+@pytest.fixture
+def docs() -> Iterator[Document]:
+    # if using yield, the pytest fixture does not work quite as expected
+    docs = []
+    for i in range(2):
+        docs.append(
+            Document(
+                id=str(i),
+                text=f"text {i}",
+                metadata={
+                    "one": "something",
+                    "two": "something else",
+                },
+                context=None,
+            ),
+        )
+    return (d for d in docs)
+
+
+def test_metadata_filtering_removes_field(docs):
+    preprocessor = Preprocessor(metadata_fields={"one"})
+    filtered = list(preprocessor._filter_metadata(docs))
+    assert len(filtered) == 2
+    for doc in filtered:
+        assert "one" in doc["metadata"] and "two" not in doc["metadata"]
+
+
+def test_metadata_filtering_retains_all(docs):
+    preprocessor = Preprocessor(metadata_fields={"*"})
+    filtered = list(preprocessor._filter_metadata(docs))
+    assert len(filtered) == 2
+    for doc in filtered:
+        assert all(key in doc["metadata"] for key in ("one", "two"))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,7 +39,7 @@ def test_docs_from_jsonl(path, nlp):
 
 def test_docs_to_jsonl(nlp, docs_with_triplets):  # noqa: F811
     docs = docs_with_triplets
-    docs_to_jsonl(docs, "test.jsonl")
+    docs_to_jsonl(docs, "test.jsonl", include_span_heads=False)
     _docs = docs_from_jsonl("test.jsonl", nlp=nlp)
 
     assert len(docs) == len(_docs)


### PR DESCRIPTION
Introducing the "generic pipeline". The idea is as follows:

You bring your data, e.g. in text files, tweets in JSON lines or whatever. There are different pre-processors to handle that. They implement the method `Preprocessor._do_preprocessing()`. If your data is special, you or someone else can implement a new preprocessor to handle that data format. The rest kind of works out of the box since the data is streamlined after preprocessing.

Let' say that you have a bunch of text files in a folder under `input/my_input`. The whole thing is run with the `run.py` script as follows. 
```
python3 run.py my_project_name "input/my_input/*.txt" [-c config/my_config.toml]
```

You'll get this output:
```
output/my_project_name/
    annotations.ndjson
    graph.json
    graph.png
    nodes_edges.json
    preprocessed.ndjson
    triplets.csv
```

It can all be refined, but I figured this was a good time for review and maybe merging it in since it basically works. The rest can come down the road.

Next up is finding English components for the pipeline such that one can set `"en"` as language in configuration (or CLI argument, perhaps).