### PR TITLE
Kf/timestamped triplets

### DIFF
--- a/config/eschatology.toml
+++ b/config/eschatology.toml
@@ -8,6 +8,7 @@ doc_type = "csv"
 [preprocessing.extra]
 id_column = "id"
 text_column = "body"
+timestamp_column = "timestamp"
 
 [docprocessing]
 enabled = true

--- a/src/conspiracies/common/fileutils.py
+++ b/src/conspiracies/common/fileutils.py
@@ -16,4 +16,5 @@ def iter_lines_of_files(glob_pattern: Union[str, Path]):
     for file in files:
         with open(file) as f:
             for line in f:
-                yield line
+                if line.strip():
+                    yield line

--- a/src/conspiracies/corpusprocessing/aggregation.py
+++ b/src/conspiracies/corpusprocessing/aggregation.py
@@ -1,10 +1,21 @@
-from collections import Counter
-from typing import List, TypedDict, Dict, Union, Callable, Iterable, Tuple
+from collections import Counter, defaultdict
+from datetime import datetime
+from typing import (
+    List,
+    TypedDict,
+    Dict,
+    Union,
+    Callable,
+    Iterable,
+    Tuple,
+    Optional,
+    Any,
+)
 
 from pydantic import BaseModel
 
 from conspiracies.corpusprocessing.clustering import Mappings
-from conspiracies.corpusprocessing.triplet import Triplet
+from conspiracies.corpusprocessing.triplet import Triplet, TripletField
 
 
 def min_max_normalizer(values: Iterable[Union[int, float]]) -> Callable[[float], float]:
@@ -21,20 +32,59 @@ class StatsEntry(TypedDict):
     key: Union[str, Tuple[str]]
     frequency: int
     norm_frequency: float
+    docs: Optional[list[str]]
+    first_occurrence: Optional[datetime]
+    last_occurrence: Optional[datetime]
 
 
 class StatsDict(Dict[str, StatsEntry]):
     pass
 
     @classmethod
-    def from_counter(cls, counter: Counter):
+    def from_iterable(
+        cls,
+        generator: Iterable[Tuple[Any, Optional[str], Optional[datetime]]],
+    ):
+        counter = Counter()
+        docs = defaultdict(set)
+        first_occurrence = {}
+        last_occurrence = {}
+        for key, doc_id, timestamp in generator:
+            counter[key] += 1
+
+            if doc_id:
+                docs[key].add(doc_id)
+
+            if timestamp:
+                if key in first_occurrence:
+                    first_occurrence[key] = min(timestamp, first_occurrence[key])
+                else:
+                    first_occurrence[key] = timestamp
+
+                if key in last_occurrence:
+                    last_occurrence[key] = max(timestamp, last_occurrence[key])
+                else:
+                    last_occurrence[key] = timestamp
+
         normalizer = min_max_normalizer(counter.values())
+
         return cls(
             {
                 key: StatsEntry(
                     key=key,
                     frequency=value,
                     norm_frequency=normalizer(value),
+                    docs=list(docs[key]) if key in docs else None,
+                    first_occurrence=(
+                        first_occurrence[key].isoformat()
+                        if key in first_occurrence
+                        else None
+                    ),
+                    last_occurrence=(
+                        last_occurrence[key].isoformat()
+                        if key in last_occurrence
+                        else None
+                    ),
                 )
                 for key, value in counter.items()
             },
@@ -63,27 +113,44 @@ class TripletAggregator:
         triplets: List[Triplet],
         remove_identical_subj_and_obj: bool = True,
     ):
-        mapped_triplets = [
-            (
-                self._mappings.map_entity(triplet.subject.text),
-                self._mappings.map_predicate(triplet.predicate.text),
-                self._mappings.map_entity(triplet.object.text),
-            )
-            for triplet in triplets
-        ]
-        if remove_identical_subj_and_obj:
-            mapped_triplets = [t for t in mapped_triplets if t[0] != t[2]]
-        triplet_counts = Counter(triplet for triplet in mapped_triplets)
-        entity_counts = Counter(
-            entity for triplet in mapped_triplets for entity in (triplet[0], triplet[2])
-        )
-        # entity_distinct_triplets = Counter(
-        #     entity for triplet in set(mapped_triplets) for entity in (triplet[0], triplet[2])
-        # )
+        if self._mappings is not None:
+            triplets = [
+                Triplet(
+                    subject=TripletField(
+                        text=self._mappings.map_entity(t.subject.text),
+                    ),
+                    predicate=TripletField(
+                        text=self._mappings.map_predicate(t.predicate.text),
+                    ),
+                    object=TripletField(text=self._mappings.map_entity(t.object.text)),
+                    doc=t.doc,
+                    timestamp=t.timestamp,
+                )
+                for t in triplets
+            ]
 
-        predicate_counts = Counter(triplet[1] for triplet in mapped_triplets)
+        if remove_identical_subj_and_obj:
+            triplets = [t for t in triplets if t.subject.text != t.object.text]
+
         return TripletStats(
-            triplets=StatsDict.from_counter(triplet_counts),
-            entities=StatsDict.from_counter(entity_counts),
-            predicates=StatsDict.from_counter(predicate_counts),
+            triplets=StatsDict.from_iterable(
+                (
+                    (
+                        (t.subject.text, t.predicate.text, t.object.text),
+                        t.doc,
+                        t.timestamp,
+                    )
+                    for t in triplets
+                )
+            ),
+            entities=StatsDict.from_iterable(
+                (
+                    (entity, t.doc, t.timestamp)
+                    for t in triplets
+                    for entity in [t.subject.text, t.object.text]
+                )
+            ),
+            predicates=StatsDict.from_iterable(
+                ((t.predicate.text, t.doc, t.timestamp) for t in triplets)
+            ),
         )

--- a/src/conspiracies/corpusprocessing/clustering.py
+++ b/src/conspiracies/corpusprocessing/clustering.py
@@ -20,8 +20,20 @@ class Mappings(BaseModel):
     def map_entity(self, entity: str):
         return self.entities[entity] if entity in self.entities else entity
 
+    def entity_alt_labels(self):
+        alt_labels = defaultdict(list)
+        for entity, label in self.entities.items():
+            alt_labels[label].append(entity)
+        return alt_labels
+
     def map_predicate(self, predicate: str):
         return self.predicates[predicate] if predicate in self.predicates else predicate
+
+    def predicate_alt_labels(self):
+        alt_labels = defaultdict(list)
+        for predicate, label in self.predicates.items():
+            alt_labels[label].append(predicate)
+        return alt_labels
 
 
 class Clustering:
@@ -120,10 +132,12 @@ class Clustering:
             list(clusters.values()),
             get_combine_key=lambda t: t[0].text,
         )
-        merged = self._combine_clusters(
-            merged,
-            get_combine_key=lambda t: t[0].head,
-        )
+
+        # too risky with false positives from this
+        # merged = self._combine_clusters(
+        #     merged,
+        #     get_combine_key=lambda t: t[0].head,
+        # )
 
         # sort by how "prototypical" a member is in the cluster
         for cluster in merged:

--- a/src/conspiracies/docprocessing/docprocessor.py
+++ b/src/conspiracies/docprocessing/docprocessor.py
@@ -106,20 +106,20 @@ class DocProcessor:
                     annotated_doc["id"] for annotated_doc in annotated_docs
                 }
             print(f"Skipping {len(already_processed)} processed docs.")
-            docs = (doc for doc in docs if doc["id"] not in already_processed)
+            docs = (doc for doc in docs if doc.id not in already_processed)
 
         # The coreference pipeline tends to choke on too large batches because of an
         # extreme memory pressure, hence the small batch size
         coref_resolved_docs = self.coref_pipeline.pipe(
-            ((text_with_context(doc), doc["id"]) for doc in docs),
+            ((text_with_context(src_doc), src_doc) for src_doc in docs),
             batch_size=self.batch_size,
             as_tuples=True,
         )
 
         with_triplets = self.triplet_extraction_pipeline.pipe(
             (
-                (remove_context(doc._.resolve_coref), id_)
-                for doc, id_ in coref_resolved_docs
+                (remove_context(doc._.resolve_coref), src_doc)
+                for doc, src_doc in coref_resolved_docs
             ),
             batch_size=self.batch_size,
             as_tuples=True,

--- a/src/conspiracies/document.py
+++ b/src/conspiracies/document.py
@@ -1,20 +1,23 @@
-from typing import TypedDict, Optional
+from datetime import datetime
+from typing import Optional
+from pydantic import BaseModel
 
 
-class Document(TypedDict):
+class Document(BaseModel):
     id: str
     metadata: dict
     text: str
     context: Optional[str]
+    timestamp: Optional[datetime]
 
 
 CONTEXT_END_MARKER = "[CONTEXT_END]"
 
 
 def text_with_context(doc: Document) -> str:
-    if doc["context"] is None:
-        return doc["text"]
-    return "\n".join([doc["context"], CONTEXT_END_MARKER, doc["text"]])
+    if doc.context is None:
+        return doc.text
+    return "\n".join([doc.context, CONTEXT_END_MARKER, doc.text])
 
 
 def remove_context(text: str) -> str:

--- a/src/conspiracies/pipeline/config.py
+++ b/src/conspiracies/pipeline/config.py
@@ -37,7 +37,7 @@ class ClusteringThresholds(BaseModel):
     def estimate_from_n_triplets(cls, n_triplets: int):
         factor = n_triplets / 1000
         thresholds = cls(
-            min_cluster_size=int(factor + 1),
+            min_cluster_size=max(int(factor + 1), 2),
             min_samples=int(factor + 1),
         )
         return thresholds

--- a/src/conspiracies/pipeline/pipeline.py
+++ b/src/conspiracies/pipeline/pipeline.py
@@ -87,7 +87,7 @@ class Pipeline:
         docprocessor = self._get_docprocessor()
         docprocessor.process_docs(
             (
-                json.loads(line, object_hook=lambda d: Document(**d))
+                Document(**json.loads(line))
                 for line in iter_lines_of_files(
                     self.output_path / "preprocessed.ndjson",
                 )

--- a/src/conspiracies/preprocessing/csv.py
+++ b/src/conspiracies/preprocessing/csv.py
@@ -14,12 +14,14 @@ class CsvPreprocessor(Preprocessor):
         id_column: str = None,
         text_column: str = None,
         context_column: str = None,
+        timestamp_column: str = None,
         delimiter=",",
         metadata_fields: Iterable[str] = ("*",),
     ):
         self.id_column = id_column
         self.text_column = text_column
         self.context_column = context_column
+        self.timestamp_column = timestamp_column
         self.non_metadata_columns = {
             self.id_column,
             self.text_column,
@@ -34,6 +36,7 @@ class CsvPreprocessor(Preprocessor):
             id_ = row[self.id_column]
             text = row[self.text_column]
             context = row[self.context_column] if self.context_column else None
+            timestamp = row[self.timestamp_column] if self.timestamp_column else None
             metadata = {
                 k: v for k, v in row.items() if k not in self.non_metadata_columns
             }
@@ -42,6 +45,7 @@ class CsvPreprocessor(Preprocessor):
                 text=text,
                 context=context,
                 metadata=metadata,
+                timestamp=timestamp,
             )
 
     def _do_preprocess_docs(self, input_path: Union[str, Path]) -> Iterator[str]:

--- a/src/conspiracies/preprocessing/infomedia.py
+++ b/src/conspiracies/preprocessing/infomedia.py
@@ -32,7 +32,14 @@ class InfoMediaPreprocessor(Preprocessor):
         metadata = {k: obj[k] for k in InfoMediaPreprocessor.METADATA_KEYS}
         text = self.create_text(obj)
 
-        return Document(id=doc_id, metadata=metadata, text=text, context=None)
+        # TODO: get timestamp from metadata
+        return Document(
+            id=doc_id,
+            metadata=metadata,
+            text=text,
+            context=None,
+            timestamp=None,
+        )
 
     @staticmethod
     def create_text(doc_obj: dict):

--- a/src/conspiracies/preprocessing/preprocessor.py
+++ b/src/conspiracies/preprocessing/preprocessor.py
@@ -2,8 +2,6 @@ import logging
 from pathlib import Path
 from typing import Iterator, Iterable
 
-import ndjson
-
 from conspiracies.document import Document
 
 
@@ -28,7 +26,7 @@ class Preprocessor:
                 yield doc
 
         for doc in preprocessed_docs:
-            metadata = doc["metadata"]
+            metadata = doc.metadata
             for key in list(metadata.keys()):
                 if key not in self.metadata_fields:
                     del metadata[key]
@@ -39,10 +37,10 @@ class Preprocessor:
         preprocessed_docs: Iterator[Document],
     ) -> Iterator[Document]:
         for doc in preprocessed_docs:
-            if not doc["text"]:
+            if not doc.text:
                 logging.warning(
                     "Skipping doc with id '%s' because of empty text field",
-                    doc["id"],
+                    doc.id,
                 )
                 continue
             else:
@@ -54,5 +52,6 @@ class Preprocessor:
         if n_docs and n_docs > 0:
             validated = (d for i, d in enumerate(validated) if i < n_docs)
         metadata_filtered = self._filter_metadata(validated)
+
         with output_path.open("w+") as out_file:
-            ndjson.dump(metadata_filtered, out_file)
+            print(*(d.json() for d in metadata_filtered), file=out_file, sep="\n")

--- a/src/conspiracies/preprocessing/text.py
+++ b/src/conspiracies/preprocessing/text.py
@@ -22,4 +22,5 @@ class TextFilePreprocessor(Preprocessor):
                 text=text,
                 metadata={},
                 context=None,
+                timestamp=None,
             )

--- a/src/conspiracies/preprocessing/tweets.py
+++ b/src/conspiracies/preprocessing/tweets.py
@@ -44,4 +44,11 @@ class TweetsPreprocessor(Preprocessor):
             metadata = {k: v for k, v in tweet.items() if k != "text"}
             text = tweet["text"]
             context = "\n".join(t["text"] for t in context_tweets)
-            yield Document(id=doc_id, metadata=metadata, text=text, context=context)
+            # TODO: get timestamp from metadata
+            yield Document(
+                id=doc_id,
+                metadata=metadata,
+                text=text,
+                context=context,
+                timestamp=None,
+            )

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -20,6 +20,7 @@ def docs() -> Iterator[Document]:
                     "two": "something else",
                 },
                 context=None,
+                timestamp=None,
             ),
         )
     return (d for d in docs)
@@ -30,7 +31,7 @@ def test_metadata_filtering_removes_field(docs):
     filtered = list(preprocessor._filter_metadata(docs))
     assert len(filtered) == 2
     for doc in filtered:
-        assert "one" in doc["metadata"] and "two" not in doc["metadata"]
+        assert "one" in doc.metadata and "two" not in doc.metadata
 
 
 def test_metadata_filtering_retains_all(docs):
@@ -38,4 +39,4 @@ def test_metadata_filtering_retains_all(docs):
     filtered = list(preprocessor._filter_metadata(docs))
     assert len(filtered) == 2
     for doc in filtered:
-        assert all(key in doc["metadata"] for key in ("one", "two"))
+        assert all(key in doc.metadata for key in ("one", "two"))

--- a/visualizer/src/graph/GraphFilterControlPanel.tsx
+++ b/visualizer/src/graph/GraphFilterControlPanel.tsx
@@ -12,43 +12,56 @@ export const GraphFilterControlPanel = ({graphFilter, setGraphFilter}: GraphFilt
 
     return <div className={"flex-container"}>
         <div className={"flex-container__element"}>
-            <span className={"flex-container__member__element"}>Minimum Node Frequency: {graphFilter.minimumNodeFrequency}</span>
-            <button className={"flex-container__member__element"}
-                onClick={() => setGraphFilter({
-                    ...graphFilter,
-                    minimumNodeFrequency: graphFilter.minimumNodeFrequency + 1
-                })}>+
+            <span
+                className={"flex-container__element__sub-element"}>Minimum Node Frequency: {graphFilter.minimumNodeFrequency}</span>
+            <button className={"flex-container__element__sub-element"}
+                    onClick={() => setGraphFilter({
+                        ...graphFilter,
+                        minimumNodeFrequency: graphFilter.minimumNodeFrequency + 1
+                    })}>+
             </button>
-            <button className={"flex-container__member__element"}
-                onClick={() => setGraphFilter({
-                    ...graphFilter,
-                    minimumNodeFrequency: graphFilter.minimumNodeFrequency - 1
-                })}>-
+            <button className={"flex-container__element__sub-element"}
+                    onClick={() => setGraphFilter({
+                        ...graphFilter,
+                        minimumNodeFrequency: graphFilter.minimumNodeFrequency - 1
+                    })}>-
             </button>
         </div>
         <div className={"flex-container__element"}>
             Minimum Edge Frequency: {graphFilter.minimumEdgeFrequency}
-            <button className={"flex-container__member__element"}
-                onClick={() => setGraphFilter({
-                    ...graphFilter,
-                    minimumEdgeFrequency: graphFilter.minimumEdgeFrequency + 1
-                })}>+
+            <button className={"flex-container__element__sub-element"}
+                    onClick={() => setGraphFilter({
+                        ...graphFilter,
+                        minimumEdgeFrequency: graphFilter.minimumEdgeFrequency + 1
+                    })}>+
             </button>
-            <button className={"flex-container__member__element"}
-                onClick={() => setGraphFilter({
-                    ...graphFilter,
-                    minimumEdgeFrequency: graphFilter.minimumEdgeFrequency - 1
-                })}>-
+            <button className={"flex-container__element__sub-element"}
+                    onClick={() => setGraphFilter({
+                        ...graphFilter,
+                        minimumEdgeFrequency: graphFilter.minimumEdgeFrequency - 1
+                    })}>-
             </button>
         </div>
         <div className={"flex-container__element"}>
             Show unconnected nodes:
-            <input type={"checkbox"} className={"flex-container__member__element"}
+            <input type={"checkbox"} className={"flex-container__element__sub-element"}
                    checked={graphFilter.showUnconnectedNodes}
                    onChange={(event) => setGraphFilter({
                        ...graphFilter,
                        showUnconnectedNodes: event.target.checked
                    })}/>
+        </div>
+        <div className={"flex-container__element"}>
+            From: <input className={"flex-container__element__sub-element"} type={"date"}
+                         onChange={(event) => setGraphFilter({
+                             ...graphFilter,
+                             earliestDate: event.target.valueAsDate ?? undefined
+                         })}/>
+            To: <input className={"flex-container__element__sub-element"} type={"date"}
+                       onChange={(event) => setGraphFilter({
+                           ...graphFilter,
+                           latestDate: event.target.valueAsDate ?? undefined
+                       })}/>
         </div>
     </div>
 }

--- a/visualizer/src/graph/GraphService.ts
+++ b/visualizer/src/graph/GraphService.ts
@@ -70,6 +70,8 @@ export function filter(filter: GraphFilter, graphData: EnrichedGraphData): Enric
 }
 
 export abstract class GraphService {
+    private nodesMap: Map<string, EnrichedNode> | null = null;
+
     abstract getGraph(): EnrichedGraphData;
 
     getSubGraph(nodeIds: Set<string>): EnrichedGraphData {
@@ -85,6 +87,12 @@ export abstract class GraphService {
     }
 
     getNode(nodeId: string): EnrichedNode | undefined {
+        if (this.nodesMap === null) {
+            this.nodesMap = new Map(
+                this.getGraph().nodes.map(node => [node.id!.toString(), node])
+            )
+        }
+
         // highly inefficient linear search; overwrite for actual use
         for (let node of this.getGraph().nodes) {
             if (node.id === nodeId) {

--- a/visualizer/src/graph/GraphService.tsx
+++ b/visualizer/src/graph/GraphService.tsx
@@ -4,8 +4,8 @@ export interface Stats {
     frequency: number;
     norm_frequency?: number;
     docs?: string[];
-    first_occurrence?: Date;
-    last_occurrence?: Date;
+    first_occurrence?: string;
+    last_occurrence?: string;
     alt_labels?: string[];
 }
 
@@ -27,7 +27,7 @@ export class GraphFilter {
     minimumEdgeFrequency: number;
     earliestDate?: Date;
     latestDate?: Date;
-    showUnconnectedNodes: boolean = true;
+    showUnconnectedNodes: boolean = false;
 
     constructor(minimumNodeFrequency: number = 1, minimumEdgeFrequency: number = 1) {
         this.minimumNodeFrequency = minimumNodeFrequency;
@@ -84,11 +84,11 @@ export abstract class GraphService {
             .flatMap(edge => [edge.from!.toString(), edge.to!.toString()]))
     }
 
-    getAltLabels(nodeId: string): string[] | undefined {
+    getNode(nodeId: string): EnrichedNode | undefined {
         // highly inefficient linear search; overwrite for actual use
         for (let node of this.getGraph().nodes) {
             if (node.id === nodeId) {
-                return node.stats.alt_labels;
+                return node;
             }
         }
         return undefined;

--- a/visualizer/src/graph/GraphService.tsx
+++ b/visualizer/src/graph/GraphService.tsx
@@ -2,6 +2,11 @@ import {GraphData, Node, Edge} from "react-vis-graph-wrapper";
 
 export interface Stats {
     frequency: number;
+    norm_frequency?: number;
+    docs?: string[];
+    first_occurrence?: string;
+    last_occurrence?: string;
+    alt_labels?: string[];
 }
 
 export interface EnrichedNode extends Node {
@@ -60,6 +65,17 @@ export abstract class GraphService {
         return new Set(this.getGraph().edges.filter(edge => edge.from === nodeId || edge.to === nodeId)
             .flatMap(edge => [edge.from!.toString(), edge.to!.toString()]))
     }
+
+    getAltLabels(nodeId: string): string[] | undefined {
+        // highly inefficient linear search; overwrite for actual use
+        for (let node of this.getGraph().nodes) {
+            if (node.id === nodeId) {
+                return node.stats.alt_labels;
+            }
+        }
+        return undefined;
+    }
+
 }
 
 

--- a/visualizer/src/graph/GraphService.tsx
+++ b/visualizer/src/graph/GraphService.tsx
@@ -1,11 +1,11 @@
-import {GraphData, Node, Edge} from "react-vis-graph-wrapper";
+import {Edge, GraphData, Node} from "react-vis-graph-wrapper";
 
 export interface Stats {
     frequency: number;
     norm_frequency?: number;
     docs?: string[];
-    first_occurrence?: string;
-    last_occurrence?: string;
+    first_occurrence?: Date;
+    last_occurrence?: Date;
     alt_labels?: string[];
 }
 
@@ -25,19 +25,37 @@ export interface EnrichedGraphData extends GraphData {
 export class GraphFilter {
     minimumNodeFrequency: number;
     minimumEdgeFrequency: number;
+    earliestDate?: Date;
+    latestDate?: Date;
     showUnconnectedNodes: boolean = true;
 
     constructor(minimumNodeFrequency: number = 1, minimumEdgeFrequency: number = 1) {
         this.minimumNodeFrequency = minimumNodeFrequency;
         this.minimumEdgeFrequency = minimumEdgeFrequency;
     }
-
-
 }
+
+function hasDateOverlap(node: EnrichedNode, filter: GraphFilter): boolean {
+    if (!node.stats.first_occurrence || !node.stats.last_occurrence) {
+        return true;
+    }
+    const first = new Date(node.stats.first_occurrence);
+    const last = new Date(node.stats.last_occurrence);
+    const afterEarliestDate = !filter.earliestDate
+        || filter.earliestDate < first
+        || filter.earliestDate < last;
+
+    const beforeLatestDate = !filter.latestDate
+        || filter.latestDate > first || filter.latestDate > last;
+
+    return afterEarliestDate && beforeLatestDate;
+}
+
 
 export function filter(filter: GraphFilter, graphData: EnrichedGraphData): EnrichedGraphData {
     let nodes = graphData.nodes.filter((node: EnrichedNode) =>
         node.stats.frequency >= filter.minimumNodeFrequency
+        && hasDateOverlap(node, filter)
     );
     let filteredNodes = new Set(nodes.map(node => node.id));
     let edges = graphData.edges.filter((edge: EnrichedEdge) =>

--- a/visualizer/src/graph/GraphViewer.tsx
+++ b/visualizer/src/graph/GraphViewer.tsx
@@ -1,6 +1,7 @@
 import React, {useEffect, useRef, useState} from "react";
 import {
     EnrichedGraphData,
+    EnrichedNode,
     FileGraphService,
     filter,
     GraphFilter,
@@ -11,6 +12,7 @@ import FileUploadComponent from "../datasources/FileUploadComp";
 import Graph, {GraphEvents, Options} from "react-vis-graph-wrapper";
 import {GraphFilterControlPanel} from "./GraphFilterControlPanel";
 import {GraphOptionsControlPanel} from "./GraphOptionsControlPanel";
+import {NodeInfo} from "./NodeInfo";
 
 
 export const GraphViewer: React.FC = () => {
@@ -24,9 +26,9 @@ export const GraphViewer: React.FC = () => {
         setGraphData(filter(graphFilter, graphServiceRef.current.getGraph()));
     };
 
-    const [graphFilter, setGraphFilter] = useState(new GraphFilter(2))
+    const [graphFilter, setGraphFilter] = useState(new GraphFilter(5, 3))
     const [selected, setSelected] = useState(new Set<string>())
-    const [altLabelsOfSelectedNode, setAltLabelsOfSelectedNode] = useState<string[] | undefined>(undefined)
+    const [selectedNode, setSelectedNode] = useState<EnrichedNode | undefined>(undefined)
 
     useEffect(
         () => {
@@ -67,10 +69,10 @@ export const GraphViewer: React.FC = () => {
             setSelected(newSelected);
         },
         selectNode: ({nodes}) => {
-            setAltLabelsOfSelectedNode(graphServiceRef.current.getAltLabels(nodes[0]));
+            setSelectedNode(graphServiceRef.current.getNode(nodes[0]));
         },
         deselectNode: () => {
-            setAltLabelsOfSelectedNode(undefined);
+            setSelectedNode(undefined);
         }
     };
 
@@ -121,13 +123,7 @@ export const GraphViewer: React.FC = () => {
 
             </div>
             <div className="graph-container">
-                {altLabelsOfSelectedNode && altLabelsOfSelectedNode.length > 0 &&
-                    <div className={"alt-labels"}>
-                        <b>Alternative Labels</b>
-                        <hr/>
-                        {altLabelsOfSelectedNode.map(altLabel => <p>{altLabel}</p>)}
-                    </div>
-                }
+                {selectedNode && <NodeInfo node={selectedNode}/>}
 
                 <Graph graph={graphData} options={options} events={events}/>
             </div>

--- a/visualizer/src/graph/GraphViewer.tsx
+++ b/visualizer/src/graph/GraphViewer.tsx
@@ -121,7 +121,7 @@ export const GraphViewer: React.FC = () => {
 
             </div>
             <div className="graph-container">
-                {altLabelsOfSelectedNode &&
+                {altLabelsOfSelectedNode && altLabelsOfSelectedNode.length > 0 &&
                     <div className={"alt-labels"}>
                         <b>Alternative Labels</b>
                         <hr/>

--- a/visualizer/src/graph/GraphViewer.tsx
+++ b/visualizer/src/graph/GraphViewer.tsx
@@ -1,7 +1,8 @@
 import React, {useEffect, useRef, useState} from "react";
 import {
     EnrichedGraphData,
-    FileGraphService, filter,
+    FileGraphService,
+    filter,
     GraphFilter,
     GraphService,
     SampleGraphService,
@@ -10,8 +11,6 @@ import FileUploadComponent from "../datasources/FileUploadComp";
 import Graph, {GraphEvents, Options} from "react-vis-graph-wrapper";
 import {GraphFilterControlPanel} from "./GraphFilterControlPanel";
 import {GraphOptionsControlPanel} from "./GraphOptionsControlPanel";
-
-
 
 
 export const GraphViewer: React.FC = () => {
@@ -27,6 +26,8 @@ export const GraphViewer: React.FC = () => {
 
     const [graphFilter, setGraphFilter] = useState(new GraphFilter(2))
     const [selected, setSelected] = useState(new Set<string>())
+    const [altLabelsOfSelectedNode, setAltLabelsOfSelectedNode] = useState<string[] | undefined>(undefined)
+
     useEffect(
         () => {
             let newGraphData: EnrichedGraphData;
@@ -65,6 +66,12 @@ export const GraphViewer: React.FC = () => {
             });
             setSelected(newSelected);
         },
+        selectNode: ({nodes}) => {
+            setAltLabelsOfSelectedNode(graphServiceRef.current.getAltLabels(nodes[0]));
+        },
+        deselectNode: () => {
+            setAltLabelsOfSelectedNode(undefined);
+        }
     };
 
     let [options, setOptions] = useState<Options>({
@@ -84,12 +91,13 @@ export const GraphViewer: React.FC = () => {
 
     return (
         <div>
+
             <div className={"padded"}>
                 <FileUploadComponent onFileLoaded={handleFileLoaded}/>
             </div>
             <div className={"padded"}>
                 <GraphFilterControlPanel graphFilter={graphFilter} setGraphFilter={setGraphFilter}/>
-                <GraphOptionsControlPanel options={options} setOptions={setOptions} />
+                <GraphOptionsControlPanel options={options} setOptions={setOptions}/>
             </div>
             <div className={"padded"}>
                 <div className={"flex-container"}>
@@ -109,8 +117,18 @@ export const GraphViewer: React.FC = () => {
                         Reset selection
                     </button>
                 </div>
+
+
             </div>
             <div className="graph-container">
+                {altLabelsOfSelectedNode &&
+                    <div className={"alt-labels"}>
+                        <b>Alternative Labels</b>
+                        <hr/>
+                        {altLabelsOfSelectedNode.map(altLabel => <p>{altLabel}</p>)}
+                    </div>
+                }
+
                 <Graph graph={graphData} options={options} events={events}/>
             </div>
         </div>

--- a/visualizer/src/graph/NodeInfo.tsx
+++ b/visualizer/src/graph/NodeInfo.tsx
@@ -1,0 +1,34 @@
+import {EnrichedNode} from "./GraphService";
+import React from "react";
+
+export interface NodeInfoProps {
+    node: EnrichedNode
+    className?: string;
+}
+
+export const NodeInfo: React.FC<NodeInfoProps> = ({node, className}: NodeInfoProps) => {
+    const stats = node.stats;
+    return <div className={"node-info " + className}>
+        <b>{node.label}</b>
+        <hr/>
+        <div>
+            <p>Frequency: {stats.frequency}</p>
+            <p>Norm. frequency: {stats.norm_frequency?.toPrecision(3)}</p>
+            {stats.first_occurrence && <p>Earliest date: {stats.first_occurrence}</p>}
+            {stats.last_occurrence && <p>Latest date: {stats.last_occurrence}</p>}
+            {stats.alt_labels &&
+                <div>
+                    Labels:
+                    <ul>{stats.alt_labels.map(l => <li key={l}>{l}</li>)}</ul>
+                </div>
+            }
+            {stats.docs &&
+                <details>
+                    <summary>Documents</summary>
+                    <ul>{stats.docs.map(d => <li key={d}>{d}</li>)}</ul>
+                </details>
+            }
+        </div>
+
+    </div>
+}

--- a/visualizer/src/graph/graph.css
+++ b/visualizer/src/graph/graph.css
@@ -20,7 +20,7 @@
     margin-left: 0;
 }
 
-.flex-container__member__element {
+.flex-container__element__sub-element {
     margin: 2px;
 }
 

--- a/visualizer/src/graph/graph.css
+++ b/visualizer/src/graph/graph.css
@@ -24,12 +24,13 @@
     margin: 2px;
 }
 
-.alt-labels {
+.node-info {
     position: absolute;
     z-index: 3;
     background: white;
     border: solid 1px gray;
     font-size: small;
+    max-width: 250px;
     padding: 5px;
     margin: 2px;
 }

--- a/visualizer/src/graph/graph.css
+++ b/visualizer/src/graph/graph.css
@@ -24,6 +24,17 @@
     margin: 2px;
 }
 
+.alt-labels {
+    position: absolute;
+    z-index: 3;
+    background: white;
+    border: solid 1px gray;
+    font-size: small;
+    padding: 5px;
+    margin: 2px;
+}
+
+
 .graph-container {
     height: 80vh;
     border: 1px inset;


### PR DESCRIPTION
This PR introduces two new things to the output of the pipeline and its use in the visualizer:
1. timestamps per triplet, allowing to filter dynamically on the visualizer.
2. alternative labels (and other info) which is shown in a node info box when a node is selected in the visualizer.

![image](https://github.com/centre-for-humanities-computing/conspiracies/assets/42898679/16a163a2-a7c6-4471-8f09-94d654c20c7e)

To make some of it happen, I have changed some things in how data is passed on in the pipeline and how triplet/entity/predicate stats are aggregated. This should allow for more easy adding of other metadata or stats that we want to output in the end.